### PR TITLE
Add Google Scholar stats automation

### DIFF
--- a/.github/workflows/update_publications.yml
+++ b/.github/workflows/update_publications.yml
@@ -1,0 +1,36 @@
+name: Update Google Scholar data
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Run scraper
+        run: python scripts/update_publication_stats.py
+      - name: Commit changes
+        run: |
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@github.com'
+          git add publications.csv publications_stats.csv
+          if git diff --cached --quiet; then
+            echo 'No changes'
+          else
+            git commit -m "Update publication stats"
+            git push
+          fi
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .

--- a/publications.csv
+++ b/publications.csv
@@ -1,0 +1,1 @@
+Title,Authors,Venue,Year,Citations

--- a/publications.html
+++ b/publications.html
@@ -283,6 +283,17 @@
 
 <a href="https://scholar.google.com.pk/citations?user=6ZB86uYAAAAJ&hl=en"><img src="google_scholar.png" align="right" style="padding-top:30px;height: 500px;"></a>
 
+<table id="stats-table" style="margin-top:20px;border-collapse:collapse;" class="gsc_rsb_s gsc_prf_pnl">
+  <thead>
+    <tr>
+      <th class="gsc_rsb_sth"></th>
+      <th class="gsc_rsb_sth">All</th>
+      <th class="gsc_rsb_sth">Since 2020</th>
+    </tr>
+  </thead>
+  <tbody id="stats-table-body"></tbody>
+</table>
+
 
 
 
@@ -599,6 +610,7 @@ var sc_project=9665684;
 var sc_invisible=1; 
 var sc_security="193c50ed"; 
 </script>
+<script type="text/javascript" src="scripts/renderStats.js"></script>
 <script type="text/javascript"
 src="https://www.statcounter.com/counter/counter.js"
 async></script>

--- a/publications_stats.csv
+++ b/publications_stats.csv
@@ -1,0 +1,4 @@
+Metric,All,Since2020
+Citations,911,735
+h-index,15,13
+i10-index,15,13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/scripts/renderStats.js
+++ b/scripts/renderStats.js
@@ -1,0 +1,22 @@
+function loadStats() {
+    fetch('publications_stats.csv')
+        .then(function(res) { return res.text(); })
+        .then(function(text) {
+            var lines = text.trim().split(/\r?\n/);
+            lines.shift();
+            var tbody = document.getElementById('stats-table-body');
+            if (!tbody) return;
+            lines.forEach(function(line) {
+                var parts = line.split(',');
+                var tr = document.createElement('tr');
+                parts.forEach(function(value) {
+                    var td = document.createElement('td');
+                    td.textContent = value;
+                    tr.appendChild(td);
+                });
+                tbody.appendChild(tr);
+            });
+        });
+}
+
+document.addEventListener('DOMContentLoaded', loadStats);

--- a/scripts/renderStats.ts
+++ b/scripts/renderStats.ts
@@ -1,0 +1,28 @@
+interface MetricRow {
+    Metric: string;
+    All: string;
+    Since2020: string;
+}
+
+function loadStats() {
+    fetch('publications_stats.csv')
+        .then(res => res.text())
+        .then(text => {
+            const lines = text.trim().split(/\r?\n/);
+            lines.shift(); // remove header
+            const tbody = document.getElementById('stats-table-body');
+            if (!tbody) return;
+            lines.forEach(line => {
+                const [metric, all, since] = line.split(',');
+                const tr = document.createElement('tr');
+                [metric, all, since].forEach(value => {
+                    const td = document.createElement('td');
+                    td.textContent = value;
+                    tr.appendChild(td);
+                });
+                tbody.appendChild(tr);
+            });
+        });
+}
+
+document.addEventListener('DOMContentLoaded', loadStats);

--- a/scripts/update_publication_stats.py
+++ b/scripts/update_publication_stats.py
@@ -1,0 +1,66 @@
+import requests
+from bs4 import BeautifulSoup
+import csv
+
+PROFILE_URL = "https://scholar.google.com.pk/citations?hl=en&user=6ZB86uYAAAAJ"
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100 Safari/537.36"
+}
+
+def fetch_page(url: str) -> BeautifulSoup:
+    resp = requests.get(url, headers=HEADERS, timeout=30)
+    resp.raise_for_status()
+    return BeautifulSoup(resp.text, "html.parser")
+
+
+def parse_metrics(soup: BeautifulSoup):
+    table = soup.find("table", id="gsc_rsb_st")
+    metrics = []
+    if not table:
+        return metrics
+    for row in table.select("tr"):
+        cells = row.find_all("td")
+        if len(cells) == 3:
+            metric = cells[0].get_text(strip=True)
+            all_time = cells[1].get_text(strip=True)
+            since = cells[2].get_text(strip=True)
+            metrics.append([metric, all_time, since])
+    return metrics
+
+
+def parse_publications(soup: BeautifulSoup):
+    pubs = []
+    for row in soup.select("#gsc_a_b .gsc_a_tr"):
+        title_el = row.select_one(".gsc_a_t a")
+        title = title_el.get_text(strip=True) if title_el else ""
+        author_el = row.select_one(".gsc_a_t .gs_gray")
+        authors = author_el.get_text(strip=True) if author_el else ""
+        venue_el = row.select(".gsc_a_t .gs_gray")
+        venue = venue_el[1].get_text(strip=True) if len(venue_el) > 1 else ""
+        cites_el = row.select_one(".gsc_a_c a")
+        citations = cites_el.get_text(strip=True) if cites_el else row.select_one(".gsc_a_c").get_text(strip=True)
+        year_el = row.select_one(".gsc_a_y span")
+        year = year_el.get_text(strip=True) if year_el else ""
+        pubs.append([title, authors, venue, year, citations])
+    return pubs
+
+
+def main():
+    soup = fetch_page(PROFILE_URL)
+    metrics = parse_metrics(soup)
+    pubs = parse_publications(soup)
+
+    with open("publications_stats.csv", "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Metric", "All", "Since2020"])
+        writer.writerows(metrics)
+
+    with open("publications.csv", "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Title", "Authors", "Venue", "Year", "Citations"])
+        writer.writerows(pubs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scrape Google Scholar stats with `update_publication_stats.py`
- render citation metrics on the publication page
- keep scraped data in CSV files
- automate daily update with GitHub Actions

## Testing
- `python scripts/update_publication_stats.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6846dd8f897c8329a4d88f7fe3320a53