### PR TITLE
Add Google Scholar style metrics and citation history

### DIFF
--- a/publications.html
+++ b/publications.html
@@ -237,6 +237,47 @@
       color: #1e3c72;
     }
 
+    /* Google Scholar metrics table */
+    .gsc_rsb_st {
+      margin-top: 20px;
+      border-collapse: collapse;
+    }
+    .gsc_rsb_sth, .gsc_rsb_std {
+      padding: 4px 8px;
+      border: 1px solid #ddd;
+      font-size: 14px;
+    }
+    .gsc_rsb_sth {
+      text-align: left;
+    }
+    .gsc_rsb_std {
+      text-align: right;
+    }
+
+    /* Google Scholar citation histogram */
+    .gsc_md_hist_w {
+      position: relative;
+      width: 440px;
+      height: 220px;
+    }
+    .gsc_md_hist_b {
+      position: absolute;
+      bottom: 0;
+      width: 100%;
+      height: 100%;
+    }
+    .gsc_g_a {
+      position: absolute;
+      bottom: 0;
+      width: 32px;
+      background-color: #4d89f9;
+    }
+    .gsc_g_t {
+      position: absolute;
+      bottom: -20px;
+      font-size: 11px;
+    }
+
     </style>
 </head>
 <body>
@@ -283,7 +324,7 @@
 
 <a href="https://scholar.google.com.pk/citations?user=6ZB86uYAAAAJ&hl=en"><img src="google_scholar.png" align="right" style="padding-top:30px;height: 500px;"></a>
 
-<table id="stats-table" style="margin-top:20px;border-collapse:collapse;" class="gsc_rsb_s gsc_prf_pnl">
+<table id="gsc_rsb_st" class="gsc_rsb_st gsc_prf_pnl">
   <thead>
     <tr>
       <th class="gsc_rsb_sth"></th>
@@ -293,6 +334,8 @@
   </thead>
   <tbody id="stats-table-body"></tbody>
 </table>
+
+<div id="citation-history" style="margin-top:20px;"></div>
 
 
 

--- a/scripts/renderStats.js
+++ b/scripts/renderStats.js
@@ -9,9 +9,10 @@ function loadStats() {
             lines.forEach(function(line) {
                 var parts = line.split(',');
                 var tr = document.createElement('tr');
-                parts.forEach(function(value) {
+                parts.forEach(function(value, idx) {
                     var td = document.createElement('td');
                     td.textContent = value;
+                    td.className = idx === 0 ? 'gsc_rsb_sth' : 'gsc_rsb_std';
                     tr.appendChild(td);
                 });
                 tbody.appendChild(tr);
@@ -19,4 +20,18 @@ function loadStats() {
         });
 }
 
-document.addEventListener('DOMContentLoaded', loadStats);
+function loadCitationHistory() {
+    fetch('citation_history.html')
+        .then(function(res) { return res.text(); })
+        .then(function(html) {
+            var container = document.getElementById('citation-history');
+            if (container) {
+                container.innerHTML = html;
+            }
+        });
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    loadStats();
+    loadCitationHistory();
+});

--- a/scripts/renderStats.ts
+++ b/scripts/renderStats.ts
@@ -15,9 +15,10 @@ function loadStats() {
             lines.forEach(line => {
                 const [metric, all, since] = line.split(',');
                 const tr = document.createElement('tr');
-                [metric, all, since].forEach(value => {
+                [metric, all, since].forEach((value, idx) => {
                     const td = document.createElement('td');
                     td.textContent = value;
+                    td.className = idx === 0 ? 'gsc_rsb_sth' : 'gsc_rsb_std';
                     tr.appendChild(td);
                 });
                 tbody.appendChild(tr);
@@ -25,4 +26,18 @@ function loadStats() {
         });
 }
 
-document.addEventListener('DOMContentLoaded', loadStats);
+function loadCitationHistory() {
+    fetch('citation_history.html')
+        .then(res => res.text())
+        .then(html => {
+            const container = document.getElementById('citation-history');
+            if (container) {
+                container.innerHTML = html;
+            }
+        });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadStats();
+    loadCitationHistory();
+});

--- a/scripts/update_publication_stats.py
+++ b/scripts/update_publication_stats.py
@@ -46,10 +46,16 @@ def parse_publications(soup: BeautifulSoup):
     return pubs
 
 
+def parse_citation_history(soup: BeautifulSoup) -> str:
+    hist = soup.find("div", class_="gsc_md_hist_w")
+    return str(hist) if hist else ""
+
+
 def main():
     soup = fetch_page(PROFILE_URL)
     metrics = parse_metrics(soup)
     pubs = parse_publications(soup)
+    hist_html = parse_citation_history(soup)
 
     with open("publications_stats.csv", "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
@@ -60,6 +66,10 @@ def main():
         writer = csv.writer(f)
         writer.writerow(["Title", "Authors", "Venue", "Year", "Citations"])
         writer.writerows(pubs)
+
+    if hist_html:
+        with open("citation_history.html", "w", encoding="utf-8") as f:
+            f.write(hist_html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- scrape citation history during stats update
- display citation history on the publications page
- format stats table to mimic Google Scholar

## Testing
- `python -m py_compile scripts/update_publication_stats.py`

------
https://chatgpt.com/codex/tasks/task_e_684718ae596c83299111b70bc771b260