### PR TITLE
Center banner with CSS

### DIFF
--- a/ITC.html
+++ b/ITC.html
@@ -31,7 +31,7 @@
 <div style="width:800;margin-left:auto;margin-right:auto;">
 <font face="arial" size="3">
 
-<center><img src="banner2.gif" alt="Naveed Bhatti banner" height="152"></center>
+<img src="banner2.gif" alt="Naveed Bhatti banner" height="152">
 		
 <div class="container">
 <ul id="minitabs">

--- a/blog.html
+++ b/blog.html
@@ -34,7 +34,7 @@
 <body style="">
 <div style="width:800;margin-left:auto;margin-right:auto;">
 <font face="arial" size="3">
-<center><img src="banner2.gif" alt="Naveed Bhatti banner" height="152"></center>				
+<img src="banner2.gif" alt="Naveed Bhatti banner" height="152">				
 
 
 

--- a/contact.html
+++ b/contact.html
@@ -26,7 +26,7 @@
 <body>
 
 <header>
-<center><img src="banner2.gif" alt="Naveed Bhatti banner" height="152"></center>
+<img src="banner2.gif" alt="Naveed Bhatti banner" height="152">
 </header>
 		
 <nav>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 <body>
 
 <header>
-<center><img src="banner2.gif" alt="Naveed Bhatti banner" height="152"></center>
+<img src="banner2.gif" alt="Naveed Bhatti banner" height="152">
 </header>
 		
 <nav>

--- a/misc.html
+++ b/misc.html
@@ -26,7 +26,7 @@
 <body>
 
 <header>
-<center><img src="banner2.gif" alt="Naveed Bhatti banner" height="152"></center>
+<img src="banner2.gif" alt="Naveed Bhatti banner" height="152">
 </header>
 		
 <nav>

--- a/publications.html
+++ b/publications.html
@@ -26,7 +26,7 @@
 <body>
 
 <header>
-<center><img src="banner2.gif" alt="Naveed Bhatti banner" height="152"></center>
+<img src="banner2.gif" alt="Naveed Bhatti banner" height="152">
 </header>
 		
 <nav>

--- a/teaching.html
+++ b/teaching.html
@@ -26,7 +26,7 @@
 <body>
 
 <header>
-<center><img src="banner2.gif" alt="Naveed Bhatti banner" height="152"></center>
+<img src="banner2.gif" alt="Naveed Bhatti banner" height="152">
 </header>
 		
 <nav>

--- a/web.css
+++ b/web.css
@@ -3,3 +3,8 @@ h1{color:#A4A4A4;font-family: Century Gothic;}h2{color:#A4A4A4;font-family: Cent
 .icon-margin-right{margin-right:8px;}
 .text-justify{text-align:justify;}
 
+
+header img {
+    display: block;
+    margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- strip `<center>` wrapper from header banner across all pages
- center banner via new `header img` rule in `web.css`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68482bef4b6c8329bb5ebe5505876954