### PR TITLE
Align stats and ranking panels to end at Q4 and compact citation graph

### DIFF
--- a/pages/publications.html
+++ b/pages/publications.html
@@ -34,7 +34,7 @@
             display:grid;
             grid-template-columns: 1fr 1fr;
             gap: 14px;
-            align-items: stretch;
+            align-items: start;
             margin-top: 8px;
         }
         @media (max-width: 980px){
@@ -50,11 +50,10 @@
             box-shadow: 0 10px 22px rgba(15, 23, 42, 0.06);
             display: flex;
             flex-direction: column;
-            height: 100%;
         }
 
         /* tighter left stats panel */
-        .panel-scholars{ padding: 10px; }
+        .panel-scholars{ padding: 6px; }
 
 
         /* ===== Scholar stats (left) ===== */
@@ -62,24 +61,24 @@
             display:flex;
             align-items:center;
             gap: 8px;
-            margin-bottom: 8px;
+            margin-bottom: 6px;
         }
         .stats-title-icon{
-            width: 26px;
-            height: 26px;
+            width: 24px;
+            height: 24px;
             border-radius: 8px;
         }
         .stats-title-main{
             font-family: Poppins, Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
             font-weight: 800;
-            font-size: 1.08rem;
+            font-size: 1.02rem;
             color: #0f172a;
         }
         .stats-title-source{
             color: rgba(15, 23, 42, 0.62);
             font-weight: 650;
             margin-left: 6px;
-            font-size: 0.86rem;
+            font-size: 0.82rem;
         }
 
         /* Force vertical stack even if global CSS targets the ID */
@@ -87,7 +86,7 @@
             display:flex !important;
             flex-direction:column !important;
             align-items: stretch;
-            gap: 10px;
+            gap: 3px;
         }
         #scholar-stats-container > *{ width: 100%; }
 
@@ -95,25 +94,25 @@
         .citation-graph-container{
             background: rgba(255,255,255,0.92);
             border: 1px solid rgba(15, 23, 42, 0.08);
-            border-radius: 14px;
-            padding: 8px;
+            border-radius: 12px;
+            padding: 3px 4px;
         }
 
         #stats-table{
             width: 100%;
             border-collapse: collapse;
-            font-size: 0.81rem;
+            font-size: 0.78rem;
         }
         #stats-table thead th{
             text-align: left;
             color: rgba(15, 23, 42, 0.70);
             font-weight: 850;
             letter-spacing: 0.04em;
-            padding: 6px 5px;
+            padding: 3px 4px;
             border-bottom: 1px solid rgba(15, 23, 42, 0.10);
         }
         #stats-table tbody td{
-            padding: 7px 5px;
+            padding: 4px 4px;
             border-bottom: 1px solid rgba(15, 23, 42, 0.08);
             font-weight: 700;
             color: #0f172a;
@@ -132,8 +131,8 @@
             font-family: Poppins, Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
             font-weight: 800;
             color: #0f172a;
-            margin-bottom: 4px;
-            font-size: 0.90rem;
+            margin-bottom: 0;
+            font-size: 0.82rem;
         }
 
         /* Bars: full-width, evenly distributed */
@@ -143,7 +142,8 @@
             justify-content: space-between;
             align-items: flex-end;
             width: 100%;
-            height: clamp(84px, 11.5vw, 96px);
+            height: clamp(24px, 3.1vw, 30px);
+            min-height: clamp(24px, 3.1vw, 30px);
             padding: 0 2px 2px;
         }
         .graph-bar-item{
@@ -152,7 +152,7 @@
             display:flex;
             flex-direction: column;
             align-items: center;
-            gap: 3px;
+            gap: 2px;
         }
         .graph-bar{
             width: 100%;
@@ -163,13 +163,13 @@
         .bar-label{
             font-weight: 850;
             color: rgba(15, 23, 42, 0.55);
-            font-size: 0.68rem;
+            font-size: 0.60rem;
             line-height: 1;
         }
         .year-label{
             font-weight: 850;
             color: rgba(15, 23, 42, 0.60);
-            font-size: 0.68rem;
+            font-size: 0.60rem;
             line-height: 1;
         }
 
@@ -178,8 +178,8 @@
             display:flex;
             align-items:center;
             justify-content: space-between;
-            gap: 10px;
-            margin-bottom: 8px;
+            gap: 8px;
+            margin-bottom: 6px;
         }
         .rank-summary-title{
             font-family: Poppins, Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
@@ -215,8 +215,8 @@
         .rank-section{
             background: rgba(248, 250, 252, 0.78);
             border: 1px solid rgba(15, 23, 42, 0.08);
-            border-radius: 14px;
-            padding: 8px;
+            border-radius: 12px;
+            padding: 6px;
         }
         .rank-section h4{
             margin: 0 0 6px;

--- a/scripts/renderStats.js
+++ b/scripts/renderStats.js
@@ -91,7 +91,7 @@ function renderCitationGraph(text) {
   const maxCitations = Math.max(...recentHistory.map(d => d.citations));
   const containerHeight = graphContainer.clientHeight || 112;
   // Reserve vertical space for value + year labels and small gaps.
-  const graphHeight = Math.max(46, containerHeight - 34);
+  const graphHeight = Math.max(24, containerHeight - 28);
 
   recentHistory.forEach(data => {
     const barItem = document.createElement('div');


### PR DESCRIPTION
### Motivation
- Make the right-hand "Ranking Summary" card end immediately after the "Q4" pill by preventing the two top cards from stretching to equal height. 
- Shrink the left "Statistics" area (table spacing, paddings and labels) and the "Citations per year" chart so both top panels visually align and stop near the Q4 row.

### Description
- Stopped forcing equal column height by setting `.stats-rank-grid { align-items: start; }` and removed the panel `height: 100%` so the ranking card can end naturally. (modified `pages/publications.html`).
- Compacted the Statistics panel by reducing paddings, gaps, font-sizes and table cell paddings, and decreased the citation graph label spacing to reduce overall vertical footprint. (modified `pages/publications.html`).
- Overrode the citation chart size by lowering the `#citation-graph` `height` and adding a `min-height` override so it can actually shrink, and added `min-height` to keep consistent sizing. (modified `pages/publications.html`).
- Updated the citation rendering in `scripts/renderStats.js` to use a smaller plotting area (`graphHeight = Math.max(24, containerHeight - 28)`) so bar heights remain proportional within the reduced chart height. (modified `scripts/renderStats.js`).
- Slightly tightened ranking section paddings and card border radii for visual consistency. (modified `pages/publications.html`).

### Testing
- Served the site locally with `python3 -m http.server 4173` and confirmed the pages loaded successfully (succeeded). 
- Captured Playwright screenshots of `http://127.0.0.1:4173/pages/publications.html` to verify visual alignment of the Ranking Summary and Statistics panels (artifact generated; succeeded). 
- Verified changes staged and committed (`git status` / `git commit`) to ensure only intended files were modified (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ce8bf024832991d623cad10685aa)